### PR TITLE
set compiler flags globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(ament_cmake REQUIRED)
 
 include_directories(include)
 
+if(NOT WIN32)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 set(utilities_sources
   src/cmdline_parser.c
   src/concat.c
@@ -31,10 +36,8 @@ install(TARGETS c_utilities
   RUNTIME DESTINATION bin)
 
 if(BUILD_TESTING)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+  if(NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    add_compile_options(-Wall -Wextra -Wpedantic)
   endif()
 
   find_package(ament_cmake_gtest REQUIRED)

--- a/src/cmdline_parser.c
+++ b/src/cmdline_parser.c
@@ -19,8 +19,7 @@
 bool cli_option_exist(char ** begin, char ** end, const char * option)
 {
   // return std::find(begin, end, option) != end;
-  size_t i;
-  for (i = 0; i < (size_t)(end - begin); ++i) {
+  for (size_t i = 0; i < (size_t)(end - begin); ++i) {
     if (strcmp(begin[i], option) == 0) {
       return true;
     }

--- a/src/find.c
+++ b/src/find.c
@@ -28,7 +28,6 @@ size_t
 utilities_find(const char * str, char delimiter)
 {
   if (!str || strlen(str) == 0) {
-    string_array_t empty_array = {0, NULL};
     return 0;
   }
 
@@ -45,7 +44,6 @@ size_t
 utilities_find_last(const char * str, char delimiter)
 {
   if (!str || strlen(str) == 0) {
-    string_array_t empty_array = {0, NULL};
     return 0;
   }
 


### PR DESCRIPTION
Address the following comments:
* https://github.com/ros2/c_utilities/issues/7#issuecomment-291198285
* https://github.com/ros2/c_utilities/pull/8#issuecomment-291198373

CI builds:
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2382)](http://ci.ros2.org/job/ci_linux/2382/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1839)](http://ci.ros2.org/job/ci_osx/1839/) the compiler warning has been addressed in the second commit
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2503)](http://ci.ros2.org/job/ci_windows/2503/)