### PR TITLE
use _strdup() on windows to avoid compiler warning

### DIFF
--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -16,6 +16,10 @@
 
 #include "c_utilities/types/string_array.h"
 
+#ifdef _WIN32
+  #define strdup _strdup
+#endif
+
 TEST(test_string_array, boot_string_array) {
   // UNDEFIEND BEHAVIOR
   // string_array_t sa00;


### PR DESCRIPTION
Aiming to squash these warnings:

http://ci.ros2.org/job/ci_windows/2524/warnings41Result/

Following guidance from here:

http://stackoverflow.com/questions/7582394/strdup-or-strdup#7582741