### PR TITLE
Allocator and error handling in c utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ include_directories(include)
 
 if(NOT WIN32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  # The warning flags are added per target, because otherwise the local
+  # gmock library that is built will have compiler warnings.
+  set(c_utilities_extra_warning_flags "-Wall -Wextra -Wpedantic")
 endif()
 
 set(utilities_sources
@@ -29,6 +31,7 @@ add_library(
   c_utilities
   SHARED
   ${utilities_sources})
+set_target_properties(c_utilities PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -66,8 +69,22 @@ if(BUILD_TESTING)
     set(SKIP_TEST_IF_WIN32 "SKIP_TEST")
   endif()
 
+  macro(c_utilities_custom_add_gtest target)
+    ament_add_gtest(${target} ${ARGN})
+    if(TARGET ${target})
+      set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
+    endif()
+  endmacro()
+
+  macro(c_utilities_custom_add_gmock target)
+    ament_add_gmock(${target} ${ARGN})
+    if(TARGET ${target})
+      set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
+    endif()
+  endmacro()
+
   # Gtests
-  ament_add_gtest(test_allocator test/test_allocator.cpp
+  c_utilities_custom_add_gtest(test_allocator test/test_allocator.cpp
     ENV ${extra_test_env}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     ${SKIP_TEST_IF_WIN32}
@@ -76,7 +93,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_allocator c_utilities ${extra_test_libraries})
   endif()
 
-  ament_add_gmock(test_error_handling test/test_error_handling.cpp
+  c_utilities_custom_add_gmock(test_error_handling test/test_error_handling.cpp
     # Append the directory of libc_utilities so it is found at test time.
     APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:c_utilities>"
   )
@@ -84,35 +101,35 @@ if(BUILD_TESTING)
     target_link_libraries(test_error_handling ${PROJECT_NAME})
   endif()
 
-  ament_add_gtest(test_split
+  c_utilities_custom_add_gtest(test_split
     test/test_split.cpp
   )
   if(TARGET test_split)
     target_link_libraries(test_split c_utilities)
   endif()
 
-  ament_add_gtest(test_find
+  c_utilities_custom_add_gtest(test_find
     test/test_find.cpp
   )
   if(TARGET test_find)
     target_link_libraries(test_find c_utilities)
   endif()
 
-  ament_add_gtest(test_concat
+  c_utilities_custom_add_gtest(test_concat
     test/test_concat.cpp
   )
   if(TARGET test_concat)
     target_link_libraries(test_concat c_utilities)
   endif()
 
-  ament_add_gtest(test_string_array
+  c_utilities_custom_add_gtest(test_string_array
     test/test_string_array.cpp
   )
   if(TARGET test_string_array)
     target_link_libraries(test_string_array c_utilities)
   endif()
 
-  ament_add_gtest(test_get_env test/test_get_env.cpp
+  c_utilities_custom_add_gtest(test_get_env test/test_get_env.cpp
     ENV
       EMPTY_TEST=
       NORMAL_TEST=foo
@@ -120,15 +137,9 @@ if(BUILD_TESTING)
   )
   if(TARGET test_get_env)
     target_link_libraries(test_get_env ${PROJECT_NAME})
-    if(UNIX AND NOT APPLE)
-      target_link_libraries(test_get_env pthread)
-    endif()
-    if(NOT WIN32)
-      set_target_properties(test_get_env PROPERTIES COMPILE_FLAGS "-std=c++11")
-    endif()
   endif()
 
-  ament_add_gtest(test_filesystem
+  c_utilities_custom_add_gtest(test_filesystem
     test/test_filesystem.cpp
   )
   if(TARGET test_filesystem)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if(BUILD_TESTING)
   endif()
 
   find_package(ament_cmake_gmock REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
@@ -66,7 +67,7 @@ if(BUILD_TESTING)
   endif()
 
   # Gtests
-  ament_add_gmock(test_allocator test/test_allocator.cpp
+  ament_add_gtest(test_allocator test/test_allocator.cpp
     ENV ${extra_test_env}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     ${SKIP_TEST_IF_WIN32}
@@ -83,35 +84,35 @@ if(BUILD_TESTING)
     target_link_libraries(test_error_handling ${PROJECT_NAME})
   endif()
 
-  ament_add_gmock(test_split
+  ament_add_gtest(test_split
     test/test_split.cpp
   )
   if(TARGET test_split)
     target_link_libraries(test_split c_utilities)
   endif()
 
-  ament_add_gmock(test_find
+  ament_add_gtest(test_find
     test/test_find.cpp
   )
   if(TARGET test_find)
     target_link_libraries(test_find c_utilities)
   endif()
 
-  ament_add_gmock(test_concat
+  ament_add_gtest(test_concat
     test/test_concat.cpp
   )
   if(TARGET test_concat)
     target_link_libraries(test_concat c_utilities)
   endif()
 
-  ament_add_gmock(test_string_array
+  ament_add_gtest(test_string_array
     test/test_string_array.cpp
   )
   if(TARGET test_string_array)
     target_link_libraries(test_string_array c_utilities)
   endif()
 
-  ament_add_gmock(test_get_env test/test_get_env.cpp
+  ament_add_gtest(test_get_env test/test_get_env.cpp
     ENV
       EMPTY_TEST=
       NORMAL_TEST=foo
@@ -127,7 +128,7 @@ if(BUILD_TESTING)
     endif()
   endif()
 
-  ament_add_gmock(test_filesystem
+  ament_add_gtest(test_filesystem
     test/test_filesystem.cpp
   )
   if(TARGET test_filesystem)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(utilities_sources
   src/allocator.c
   src/cmdline_parser.c
   src/concat.c
+  src/error_handling.c
   src/filesystem.c
   src/find.c
   src/get_env.c
@@ -33,6 +34,11 @@ add_library(
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(c_utilities PRIVATE "C_UTILITIES_BUILDING_DLL")
 
+# Needed if pthread is used for thread local storage.
+if(IOS AND IOS_SDK_VERSION LESS 10.0)
+  ament_export_libraries(pthread)
+endif()
+
 install(TARGETS c_utilities
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -43,7 +49,7 @@ if(BUILD_TESTING)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
   endif()
 
-  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
@@ -60,7 +66,7 @@ if(BUILD_TESTING)
   endif()
 
   # Gtests
-  ament_add_gtest(test_allocator test/test_allocator.cpp
+  ament_add_gmock(test_allocator test/test_allocator.cpp
     ENV ${extra_test_env}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     ${SKIP_TEST_IF_WIN32}
@@ -69,35 +75,43 @@ if(BUILD_TESTING)
     target_link_libraries(test_allocator c_utilities ${extra_test_libraries})
   endif()
 
-  ament_add_gtest(test_split
+  ament_add_gmock(test_error_handling test/test_error_handling.cpp
+    # Append the directory of libc_utilities so it is found at test time.
+    APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:c_utilities>"
+  )
+  if(TARGET test_error_handling)
+    target_link_libraries(test_error_handling ${PROJECT_NAME})
+  endif()
+
+  ament_add_gmock(test_split
     test/test_split.cpp
   )
   if(TARGET test_split)
     target_link_libraries(test_split c_utilities)
   endif()
 
-  ament_add_gtest(test_find
+  ament_add_gmock(test_find
     test/test_find.cpp
   )
   if(TARGET test_find)
     target_link_libraries(test_find c_utilities)
   endif()
 
-  ament_add_gtest(test_concat
+  ament_add_gmock(test_concat
     test/test_concat.cpp
   )
   if(TARGET test_concat)
     target_link_libraries(test_concat c_utilities)
   endif()
 
-  ament_add_gtest(test_string_array
+  ament_add_gmock(test_string_array
     test/test_string_array.cpp
   )
   if(TARGET test_string_array)
     target_link_libraries(test_string_array c_utilities)
   endif()
 
-  ament_add_gtest(test_get_env test/test_get_env.cpp
+  ament_add_gmock(test_get_env test/test_get_env.cpp
     ENV
       EMPTY_TEST=
       NORMAL_TEST=foo
@@ -113,7 +127,7 @@ if(BUILD_TESTING)
     endif()
   endif()
 
-  ament_add_gtest(test_filesystem
+  ament_add_gmock(test_filesystem
     test/test_filesystem.cpp
   )
   if(TARGET test_filesystem)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT WIN32)
 endif()
 
 set(utilities_sources
+  src/allocator.c
   src/cmdline_parser.c
   src/concat.c
   src/filesystem.c
@@ -46,7 +47,28 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  set(extra_test_libraries)
+  set(extra_test_env)
+  set(extra_lib_dirs)
+
+  # This subdirectory extends both extra_test_libraries, extra_test_env, and extra_lib_dirs.
+  add_subdirectory(test/memory_tools)
+
+  set(SKIP_TEST_IF_WIN32 "")
+  if(WIN32)  # (memory tools doesn't do anything on Windows)
+    set(SKIP_TEST_IF_WIN32 "SKIP_TEST")
+  endif()
+
   # Gtests
+  ament_add_gtest(test_allocator test/test_allocator.cpp
+    ENV ${extra_test_env}
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+    ${SKIP_TEST_IF_WIN32}
+  )
+  if(TARGET test_allocator)
+    target_link_libraries(test_allocator c_utilities ${extra_test_libraries})
+  endif()
+
   ament_add_gtest(test_split
     test/test_split.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(
   c_utilities
   SHARED
   ${utilities_sources})
-if (c_utilities_extra_warning_flags)
+if(c_utilities_extra_warning_flags)
   set_target_properties(c_utilities
     PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,10 @@ add_library(
   c_utilities
   SHARED
   ${utilities_sources})
-set_target_properties(c_utilities PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
+if (c_utilities_extra_warning_flags)
+  set_target_properties(c_utilities
+    PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
+endif()
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -71,14 +74,14 @@ if(BUILD_TESTING)
 
   macro(c_utilities_custom_add_gtest target)
     ament_add_gtest(${target} ${ARGN})
-    if(TARGET ${target})
+    if(TARGET ${target} AND c_utilities_extra_warning_flags)
       set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
     endif()
   endmacro()
 
   macro(c_utilities_custom_add_gmock target)
     ament_add_gmock(${target} ${ARGN})
-    if(TARGET ${target})
+    if(TARGET ${target} AND c_utilities_extra_warning_flags)
       set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
     endif()
   endmacro()

--- a/include/c_utilities/allocator.h
+++ b/include/c_utilities/allocator.h
@@ -1,0 +1,101 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__ALLOCATOR_H_
+#define RCL__ALLOCATOR_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl/macros.h"
+#include "rcl/types.h"
+#include "rcl/visibility_control.h"
+
+/// Encapsulation of an allocator.
+/**
+ * The default allocator uses std::malloc(), std::free(), and std::realloc().
+ * It can be obtained using rcl_get_default_allocator().
+ *
+ * The allocator should be trivially copyable.
+ * Meaning that the struct should continue to work after being assignment
+ * copied into a new struct.
+ * Specifically the object pointed to by the state pointer should remain valid
+ * until all uses of the allocator have been made.
+ * Particular care should be taken when giving an allocator to rcl_init_* where
+ * it is stored within another object and used later.
+ */
+typedef struct rcl_allocator_t
+{
+  /// Allocate memory, given a size and the `state` pointer.
+  /** An error should be indicated by returning `NULL`. */
+  void * (*allocate)(size_t size, void * state);
+  /// Deallocate previously allocated memory, mimicking std::free().
+  /** Also takes the `state` pointer. */
+  void (* deallocate)(void * pointer, void * state);
+  /// Reallocate if possible, otherwise it deallocates and allocates.
+  /**
+   * Also takes the `state` pointer.
+   *
+   * If unsupported then do deallocate and then allocate.
+   * This should behave as std::realloc() does, as opposed to posix's
+   * [reallocf](https://linux.die.net/man/3/reallocf), i.e. the memory given
+   * by pointer will not be free'd automatically if std::realloc() fails.
+   * For reallocf-like behavior use rcl_reallocf().
+   * This function must be able to take an input pointer of `NULL` and succeed.
+   */
+  void * (*reallocate)(void * pointer, size_t size, void * state);
+  /// Implementation defined state storage.
+  /** This is passed as the final parameter to other allocator functions. */
+  void * state;
+} rcl_allocator_t;
+
+/// Return a properly initialized rcl_allocator_t with default values.
+/**
+ * This defaults to:
+ *
+ * - allocate = wraps std::malloc()
+ * - deallocate = wraps std::free()
+ * - reallocate = wrapps std::realloc()
+ * - state = `NULL`
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_allocator_t
+rcl_get_default_allocator(void);
+
+/// Emulate the behavior of [reallocf](https://linux.die.net/man/3/reallocf).
+/**
+ * This function will return `NULL` if the allocator is `NULL` or has `NULL` for
+ * function pointer fields.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+void *
+rcl_reallocf(void * pointer, size_t size, rcl_allocator_t * allocator);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCL__ALLOCATOR_H_

--- a/include/c_utilities/allocator.h
+++ b/include/c_utilities/allocator.h
@@ -12,32 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCL__ALLOCATOR_H_
-#define RCL__ALLOCATOR_H_
+#ifndef C_UTILITIES__ALLOCATOR_H_
+#define C_UTILITIES__ALLOCATOR_H_
 
 #if __cplusplus
 extern "C"
 {
 #endif
 
-#include "rcl/macros.h"
-#include "rcl/types.h"
-#include "rcl/visibility_control.h"
+#include <stddef.h>
+
+#include "c_utilities/macros.h"
+#include "c_utilities/types/utilities_ret.h"
+#include "c_utilities/visibility_control.h"
 
 /// Encapsulation of an allocator.
 /**
  * The default allocator uses std::malloc(), std::free(), and std::realloc().
- * It can be obtained using rcl_get_default_allocator().
+ * It can be obtained using utilities_get_default_allocator().
  *
  * The allocator should be trivially copyable.
  * Meaning that the struct should continue to work after being assignment
  * copied into a new struct.
  * Specifically the object pointed to by the state pointer should remain valid
  * until all uses of the allocator have been made.
- * Particular care should be taken when giving an allocator to rcl_init_* where
- * it is stored within another object and used later.
+ * Particular care should be taken when giving an allocator to functions like
+ * utilities_*_init() where it is stored within another object and used later.
  */
-typedef struct rcl_allocator_t
+typedef struct utilities_allocator_t
 {
   /// Allocate memory, given a size and the `state` pointer.
   /** An error should be indicated by returning `NULL`. */
@@ -53,16 +55,16 @@ typedef struct rcl_allocator_t
    * This should behave as std::realloc() does, as opposed to posix's
    * [reallocf](https://linux.die.net/man/3/reallocf), i.e. the memory given
    * by pointer will not be free'd automatically if std::realloc() fails.
-   * For reallocf-like behavior use rcl_reallocf().
+   * For reallocf-like behavior use utilities_reallocf().
    * This function must be able to take an input pointer of `NULL` and succeed.
    */
   void * (*reallocate)(void * pointer, size_t size, void * state);
   /// Implementation defined state storage.
   /** This is passed as the final parameter to other allocator functions. */
   void * state;
-} rcl_allocator_t;
+} utilities_allocator_t;
 
-/// Return a properly initialized rcl_allocator_t with default values.
+/// Return a properly initialized utilities_allocator_t with default values.
 /**
  * This defaults to:
  *
@@ -79,23 +81,23 @@ typedef struct rcl_allocator_t
  * Uses Atomics       | No
  * Lock-Free          | Yes
  */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_allocator_t
-rcl_get_default_allocator(void);
+C_UTILITIES_PUBLIC
+C_UTILITIES_WARN_UNUSED
+utilities_allocator_t
+utilities_get_default_allocator(void);
 
 /// Emulate the behavior of [reallocf](https://linux.die.net/man/3/reallocf).
 /**
  * This function will return `NULL` if the allocator is `NULL` or has `NULL` for
  * function pointer fields.
  */
-RCL_PUBLIC
-RCL_WARN_UNUSED
+C_UTILITIES_PUBLIC
+C_UTILITIES_WARN_UNUSED
 void *
-rcl_reallocf(void * pointer, size_t size, rcl_allocator_t * allocator);
+utilities_reallocf(void * pointer, size_t size, utilities_allocator_t * allocator);
 
 #if __cplusplus
 }
 #endif
 
-#endif  // RCL__ALLOCATOR_H_
+#endif  // C_UTILITIES__ALLOCATOR_H_

--- a/include/c_utilities/error_handling.h
+++ b/include/c_utilities/error_handling.h
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW__ERROR_HANDLING_H_
-#define RMW__ERROR_HANDLING_H_
+// Note: migrated from rmw/error_handling.h in 2017-04
+
+#ifndef C_UTILITIES__ERROR_HANDLING_H_
+#define C_UTILITIES__ERROR_HANDLING_H_
 
 #if __cplusplus
 extern "C"
@@ -23,98 +25,109 @@ extern "C"
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "rmw/macros.h"
-#include "rmw/visibility_control.h"
+#include "c_utilities/allocator.h"
+#include "c_utilities/macros.h"
+#include "c_utilities/visibility_control.h"
 
-/// Struct which encapsulates the error state set by RMW_SET_ERROR_MSG().
-typedef struct rmw_error_state_t
+/// Struct which encapsulates the error state set by UTILITIES_SET_ERROR_MSG().
+typedef struct utilities_error_state_t
 {
   const char * message;
   const char * file;
   size_t line_number;
-} rmw_error_state_t;
+  utilities_allocator_t allocator;
+} utilities_error_state_t;
 
 /// Set the error message, as well as the file and line on which it occurred.
 /**
  * This is not meant to be used directly, but instead via the
- * RMW_SET_ERROR_MSG(msg) macro.
+ * UTILITIES_SET_ERROR_MSG(msg) macro.
  *
  * The error_msg parameter is copied into the internal error storage and must
  * be null terminated.
  * The file parameter is not copied, but instead is assumed to be a global as
  * it should be set to the __FILE__ preprocessor literal when used with the
- * RMW_SET_ERROR_MSG() macro.
+ * UTILITIES_SET_ERROR_MSG() macro.
  * It should also be null terminated.
  *
- * \param error_msg The error message to set.
- * \param file The path to the file in which the error occurred.
- * \param line_number The line number on which the error occurred.
+ * The allocator is kept within the error state so that it can be used to
+ * deallocate it in the future.
+ * Therefore the allocator state needs to exist until after the last time
+ * utilities_reset_error() is called.
+ *
+ * \param[in] error_msg The error message to set.
+ * \param[in] file The path to the file in which the error occurred.
+ * \param[in] line_number The line number on which the error occurred.
+ * \param[in] allocator The allocator to be used when allocating space for the error state.
  */
-RMW_PUBLIC
+C_UTILITIES_PUBLIC
 void
-rmw_set_error_state(const char * error_msg, const char * file, size_t line_number);
+utilities_set_error_state(
+  const char * error_msg, const char * file, size_t line_number, utilities_allocator_t allocator);
 
 /// Set the error message, as well as append the current file and line number.
 /**
- * If an error message was previously set, and rmw_reset_error() was not called
- * afterwards, and this library was built with RMW_REPORT_ERROR_HANDLING_ERRORS
+ * If an error message was previously set, and utilities_reset_error() was not called
+ * afterwards, and this library was built with UTILITIES_REPORT_ERROR_HANDLING_ERRORS
  * turned on, then the previously set error message will be printed to stderr.
  * Error state storage is thread local and so all error related functions are
  * also thread local.
  *
- * \param msg The error message to be set.
+ * \param[in] msg The error message to be set.
+ * \param[in] allocator The allocator to be used when allocating space for the error state.
  */
-#define RMW_SET_ERROR_MSG(msg) rmw_set_error_state(msg, __FILE__, __LINE__);
+#define UTILITIES_SET_ERROR_MSG(msg, allocator) \
+  utilities_set_error_state(msg, __FILE__, __LINE__, allocator);
 
 /// Return `true` if the error is set, otherwise `false`.
-RMW_PUBLIC
+C_UTILITIES_PUBLIC
 bool
-rmw_error_is_set(void);
+utilities_error_is_set(void);
 
-/// Return an rmw_error_state_t which was set with rmw_set_error_state().
+/// Return an utilities_error_state_t which was set with utilities_set_error_state().
 /**
  * The returned pointer will be NULL if no error has been set in this thread.
  *
- * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state,
- * or rmw_reset_error are called in the same thread.
+ * The returned pointer is valid until UTILITIES_SET_ERROR_MSG, utilities_set_error_state,
+ * or utilities_reset_error are called in the same thread.
  *
  * \return A pointer to the current error state struct.
  */
-RMW_PUBLIC
-const rmw_error_state_t *
-rmw_get_error_state(void);
+C_UTILITIES_PUBLIC
+const utilities_error_state_t *
+utilities_get_error_state(void);
 
 /// Return the error message followed by `, at <file>:<line>`, or `NULL`.
 /**
- * The returned pointer is valid until RMW_SET_ERROR_MSG(),
- * rmw_set_error_state(), or rmw_reset_error() are called from the same thread.
+ * The returned pointer is valid until UTILITIES_SET_ERROR_MSG(),
+ * utilities_set_error_state(), or utilities_reset_error() are called from the same thread.
  *
  * \return The current formatted error string, or NULL if not set.
  */
-RMW_PUBLIC
+C_UTILITIES_PUBLIC
 const char *
-rmw_get_error_string(void);
+utilities_get_error_string(void);
 
 /// Return the error message followed by `, at <file>:<line>` if set, else "error not set".
 /**
  * This function is guaranteed to return a valid c-string.
  *
- * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state, or rmw_reset_error
- * are called in the same thread.
+ * The returned pointer is valid until UTILITIES_SET_ERROR_MSG,
+ * utilities_set_error_state, or utilities_reset_error are called in the same thread.
  *
  * \return The current error string, with file and line number, or "error not set" if not set.
  */
-RMW_PUBLIC
+C_UTILITIES_PUBLIC
 const char *
-rmw_get_error_string_safe(void);
+utilities_get_error_string_safe(void);
 
 /// Resets the error state by clearing any previously set error state.
-RMW_PUBLIC
+C_UTILITIES_PUBLIC
 void
-rmw_reset_error(void);
+utilities_reset_error(void);
 
 #if __cplusplus
 }
 #endif
 
-#endif  // RMW__ERROR_HANDLING_H_
+#endif  // C_UTILITIES__ERROR_HANDLING_H_

--- a/include/c_utilities/error_handling.h
+++ b/include/c_utilities/error_handling.h
@@ -121,7 +121,7 @@ C_UTILITIES_PUBLIC
 const char *
 utilities_get_error_string_safe(void);
 
-/// Resets the error state by clearing any previously set error state.
+/// Reset the error state by clearing any previously set error state.
 C_UTILITIES_PUBLIC
 void
 utilities_reset_error(void);

--- a/include/c_utilities/error_handling.h
+++ b/include/c_utilities/error_handling.h
@@ -1,0 +1,120 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__ERROR_HANDLING_H_
+#define RMW__ERROR_HANDLING_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "rmw/macros.h"
+#include "rmw/visibility_control.h"
+
+/// Struct which encapsulates the error state set by RMW_SET_ERROR_MSG().
+typedef struct rmw_error_state_t
+{
+  const char * message;
+  const char * file;
+  size_t line_number;
+} rmw_error_state_t;
+
+/// Set the error message, as well as the file and line on which it occurred.
+/**
+ * This is not meant to be used directly, but instead via the
+ * RMW_SET_ERROR_MSG(msg) macro.
+ *
+ * The error_msg parameter is copied into the internal error storage and must
+ * be null terminated.
+ * The file parameter is not copied, but instead is assumed to be a global as
+ * it should be set to the __FILE__ preprocessor literal when used with the
+ * RMW_SET_ERROR_MSG() macro.
+ * It should also be null terminated.
+ *
+ * \param error_msg The error message to set.
+ * \param file The path to the file in which the error occurred.
+ * \param line_number The line number on which the error occurred.
+ */
+RMW_PUBLIC
+void
+rmw_set_error_state(const char * error_msg, const char * file, size_t line_number);
+
+/// Set the error message, as well as append the current file and line number.
+/**
+ * If an error message was previously set, and rmw_reset_error() was not called
+ * afterwards, and this library was built with RMW_REPORT_ERROR_HANDLING_ERRORS
+ * turned on, then the previously set error message will be printed to stderr.
+ * Error state storage is thread local and so all error related functions are
+ * also thread local.
+ *
+ * \param msg The error message to be set.
+ */
+#define RMW_SET_ERROR_MSG(msg) rmw_set_error_state(msg, __FILE__, __LINE__);
+
+/// Return `true` if the error is set, otherwise `false`.
+RMW_PUBLIC
+bool
+rmw_error_is_set(void);
+
+/// Return an rmw_error_state_t which was set with rmw_set_error_state().
+/**
+ * The returned pointer will be NULL if no error has been set in this thread.
+ *
+ * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state,
+ * or rmw_reset_error are called in the same thread.
+ *
+ * \return A pointer to the current error state struct.
+ */
+RMW_PUBLIC
+const rmw_error_state_t *
+rmw_get_error_state(void);
+
+/// Return the error message followed by `, at <file>:<line>`, or `NULL`.
+/**
+ * The returned pointer is valid until RMW_SET_ERROR_MSG(),
+ * rmw_set_error_state(), or rmw_reset_error() are called from the same thread.
+ *
+ * \return The current formatted error string, or NULL if not set.
+ */
+RMW_PUBLIC
+const char *
+rmw_get_error_string(void);
+
+/// Return the error message followed by `, at <file>:<line>` if set, else "error not set".
+/**
+ * This function is guaranteed to return a valid c-string.
+ *
+ * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state, or rmw_reset_error
+ * are called in the same thread.
+ *
+ * \return The current error string, with file and line number, or "error not set" if not set.
+ */
+RMW_PUBLIC
+const char *
+rmw_get_error_string_safe(void);
+
+/// Resets the error state by clearing any previously set error state.
+RMW_PUBLIC
+void
+rmw_reset_error(void);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RMW__ERROR_HANDLING_H_

--- a/include/c_utilities/macros.h
+++ b/include/c_utilities/macros.h
@@ -26,10 +26,11 @@ extern "C"
 #define C_UTILITIES_WARN_UNUSED _Check_return_
 #endif
 
-// This block either sets RMW_THREAD_LOCAL or RMW_THREAD_LOCAL_PTHREAD.
+// Note: this block was migrated from rmw/macros.h
+// This block either sets UTILITIES_THREAD_LOCAL or UTILITIES_THREAD_LOCAL_PTHREAD.
 #if defined _WIN32 || defined __CYGWIN__
 // Windows or Cygwin
-  #define RMW_THREAD_LOCAL __declspec(thread)
+  #define UTILITIES_THREAD_LOCAL __declspec(thread)
 #elif defined __APPLE__
 // Apple OS's
   #include <TargetConditionals.h>
@@ -39,24 +40,24 @@ extern "C"
     #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
       #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
 // iOS >= 10, thread local storage was added in iOS 10
-        #define RMW_THREAD_LOCAL _Thread_local
+        #define UTILITIES_THREAD_LOCAL _Thread_local
       #else
 // iOS < 10, no thread local storage, so use pthread instead
-        #define RMW_THREAD_LOCAL_PTHREAD 1
-        #undef RMW_THREAD_LOCAL
+        #define UTILITIES_THREAD_LOCAL_PTHREAD 1
+        #undef UTILITIES_THREAD_LOCAL
       #endif
     #else
       #error "Unknown iOS version"
     #endif
   #elif TARGET_OS_MAC
 // macOS
-    #define RMW_THREAD_LOCAL _Thread_local
+    #define UTILITIES_THREAD_LOCAL _Thread_local
   #else
     #error "Unknown Apple platform"
   #endif
 #else
 // Some other non-Windows, non-cygwin, non-apple OS
-  #define RMW_THREAD_LOCAL _Thread_local
+  #define UTILITIES_THREAD_LOCAL _Thread_local
 #endif
 
 #define UTILITIES_STRINGIFY_IMPL(x) #x

--- a/include/c_utilities/macros.h
+++ b/include/c_utilities/macros.h
@@ -26,6 +26,39 @@ extern "C"
 #define C_UTILITIES_WARN_UNUSED _Check_return_
 #endif
 
+// This block either sets RMW_THREAD_LOCAL or RMW_THREAD_LOCAL_PTHREAD.
+#if defined _WIN32 || defined __CYGWIN__
+// Windows or Cygwin
+  #define RMW_THREAD_LOCAL __declspec(thread)
+#elif defined __APPLE__
+// Apple OS's
+  #include <TargetConditionals.h>
+  #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+// iOS Simulator or iOS device
+    #include <Availability.h>
+    #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+      #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
+// iOS >= 10, thread local storage was added in iOS 10
+        #define RMW_THREAD_LOCAL _Thread_local
+      #else
+// iOS < 10, no thread local storage, so use pthread instead
+        #define RMW_THREAD_LOCAL_PTHREAD 1
+        #undef RMW_THREAD_LOCAL
+      #endif
+    #else
+      #error "Unknown iOS version"
+    #endif
+  #elif TARGET_OS_MAC
+// macOS
+    #define RMW_THREAD_LOCAL _Thread_local
+  #else
+    #error "Unknown Apple platform"
+  #endif
+#else
+// Some other non-Windows, non-cygwin, non-apple OS
+  #define RMW_THREAD_LOCAL _Thread_local
+#endif
+
 #if __cplusplus
 }
 #endif

--- a/include/c_utilities/macros.h
+++ b/include/c_utilities/macros.h
@@ -59,6 +59,9 @@ extern "C"
   #define RMW_THREAD_LOCAL _Thread_local
 #endif
 
+#define UTILITIES_STRINGIFY_IMPL(x) #x
+#define UTILITIES_STRINGIFY(x) UTILITIES_STRINGIFY_IMPL(x)
+
 #if __cplusplus
 }
 #endif

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -1,0 +1,65 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+#include "rcl/allocator.h"
+#include "rcl/error_handling.h"
+
+static void *
+__default_allocate(size_t size, void * state)
+{
+  (void)state;  // unused
+  return malloc(size);
+}
+
+static void
+__default_deallocate(void * pointer, void * state)
+{
+  (void)state;  // unused
+  free(pointer);
+}
+
+static void *
+__default_reallocate(void * pointer, size_t size, void * state)
+{
+  (void)state;  // unused
+  return realloc(pointer, size);
+}
+
+rcl_allocator_t
+rcl_get_default_allocator()
+{
+  static rcl_allocator_t default_allocator = {
+    __default_allocate,
+    __default_deallocate,
+    __default_reallocate,
+    NULL
+  };
+  return default_allocator;
+}
+
+void *
+rcl_reallocf(void * pointer, size_t size, rcl_allocator_t * allocator)
+{
+  if (!allocator || !allocator->reallocate || !allocator->deallocate) {
+    RCL_SET_ERROR_MSG("invalid allocator or allocator function pointers");
+    return NULL;
+  }
+  void * new_pointer = allocator->reallocate(pointer, size, allocator->state);
+  if (!new_pointer) {
+    allocator->deallocate(pointer, allocator->state);
+  }
+  return new_pointer;
+}

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -22,6 +22,10 @@
 #include <c_utilities/error_handling.h>
 #include <c_utilities/macros.h>
 
+// When this define evaluates to true (default), then messages will printed to
+// stderr when an error is encoutered while setting the error state.
+// For example, when memory cannot be allocated or a previous error state is
+// being overwritten.
 #ifndef UTILITIES_REPORT_ERROR_HANDLING_ERRORS
 #define UTILITIES_REPORT_ERROR_HANDLING_ERRORS 1
 #endif

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -1,0 +1,238 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rmw/allocators.h>
+#include <rmw/error_handling.h>
+#include <rmw/impl/config.h>
+#include <rmw/macros.h>
+
+#define SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
+
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+#include <pthread.h>
+pthread_key_t __rmw_error_state_key;
+pthread_key_t __rmw_error_string_key;
+#else
+RMW_THREAD_LOCAL rmw_error_state_t * __rmw_error_state = NULL;
+RMW_THREAD_LOCAL char * __rmw_error_string = NULL;
+#endif
+
+static const char __error_format_string[] = "%s, at %s:%zu";
+
+bool
+__rmw_error_is_set(rmw_error_state_t * error_state);
+
+void
+__rmw_reset_error_string(char ** error_string_ptr);
+
+void
+__rmw_reset_error(rmw_error_state_t ** error_state_ptr_ptr);
+
+void
+rmw_set_error_state(const char * error_string, const char * file, size_t line_number)
+{
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#endif
+  rmw_error_state_t * old_error_state = __rmw_error_state;
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+  const char * old_error_string = rmw_get_error_string_safe();
+#endif
+  __rmw_error_state = (rmw_error_state_t *)rmw_allocate(sizeof(rmw_error_state_t));
+  if (!__rmw_error_state) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // rmw_allocate failed, but fwrite might work?
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to allocate memory for the error state struct\n");
+#endif
+    return;
+  }
+
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  pthread_setspecific(__rmw_error_state_key, __rmw_error_state);
+#endif
+  size_t error_string_length = strlen(error_string);
+  // the memory must be one byte bigger to store the NULL character
+  __rmw_error_state->message = (char *)malloc(error_string_length + 1);
+  if (!__rmw_error_state->message) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // malloc failed, but fwrite might work?
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to allocate memory for the error message in the error state struct\n");
+#endif
+    rmw_reset_error();  // This will free any allocations done so far.
+    return;
+  }
+  // Cast the const away to set ->message initially.
+#ifndef _WIN32
+  snprintf((char *)__rmw_error_state->message, error_string_length + 1, "%s", error_string);
+#else
+  auto retcode = strcpy_s(
+    (char *)__rmw_error_state->message, error_string_length + 1, error_string);
+  if (retcode) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to copy error message in the error state struct\n");
+#endif
+  }
+#endif
+  __rmw_error_state->file = file;
+  __rmw_error_state->line_number = line_number;
+  if (__rmw_error_is_set(old_error_state)) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // Only warn of overwritting if the new error string is different from the old ones.
+    if (error_string != old_error_string && error_string != old_error_state->message) {
+      fprintf(
+        stderr,
+        "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__) "] error string being overwritten: %s\n",
+        old_error_string);
+    }
+#endif
+    __rmw_reset_error(&old_error_state);
+  }
+  __rmw_reset_error_string(&__rmw_error_string);
+}
+
+const rmw_error_state_t *
+rmw_get_error_state()
+{
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  return (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+#else
+  return __rmw_error_state;
+#endif
+}
+
+static void
+format_error_string()
+{
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#endif
+  if (!__rmw_error_is_set(__rmw_error_state)) {
+    return;
+  }
+  size_t bytes_it_would_have_written = snprintf(
+    NULL, 0,
+    __error_format_string,
+    __rmw_error_state->message, __rmw_error_state->file, __rmw_error_state->line_number);
+  __rmw_error_string = (char *)rmw_allocate(bytes_it_would_have_written + 1);
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  pthread_setspecific(__rmw_error_string_key, __rmw_error_string);
+#endif
+  if (!__rmw_error_string) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // rmw_allocate failed, but fwrite might work?
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to allocate memory for the error string\n");
+#endif
+    return;
+  }
+  snprintf(
+    __rmw_error_string, bytes_it_would_have_written + 1,
+    __error_format_string,
+    __rmw_error_state->message, __rmw_error_state->file, __rmw_error_state->line_number);
+  // The Windows version of snprintf does not null terminate automatically in all cases.
+  __rmw_error_string[bytes_it_would_have_written] = '\0';
+}
+
+const char *
+rmw_get_error_string()
+{
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#endif
+  if (!__rmw_error_string) {
+    format_error_string();
+  }
+  return __rmw_error_string;
+}
+
+bool
+__rmw_error_is_set(rmw_error_state_t * error_state)
+{
+  return error_state != NULL;
+}
+
+bool
+rmw_error_is_set()
+{
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+#endif
+  return __rmw_error_is_set(__rmw_error_state);
+}
+
+const char *
+rmw_get_error_string_safe()
+{
+  if (!rmw_error_is_set()) {
+    return "error not set";
+  }
+  return rmw_get_error_string();
+}
+
+void
+__rmw_reset_error_string(char ** error_string_ptr)
+{
+  char * error_string = *error_string_ptr;
+  if (error_string) {
+    if (error_string) {
+      rmw_free(error_string);
+    }
+  }
+  *error_string_ptr = NULL;
+}
+
+void
+__rmw_reset_error(rmw_error_state_t ** error_state_ptr_ptr)
+{
+  rmw_error_state_t * error_state_ptr = *error_state_ptr_ptr;
+  if (error_state_ptr_ptr) {
+    if (error_state_ptr) {
+      if (error_state_ptr->message) {
+        // Cast const away to delete previously allocated memory.
+        rmw_free((char *)error_state_ptr->message);
+      }
+      rmw_free(error_state_ptr);
+    }
+  }
+  *error_state_ptr_ptr = NULL;
+}
+
+void
+rmw_reset_error()
+{
+#ifdef RMW_THREAD_LOCAL_PTHREAD
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#endif
+  __rmw_reset_error_string(&__rmw_error_string);
+  __rmw_reset_error(&__rmw_error_state);
+}

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -252,6 +252,8 @@ utilities_reset_error()
     (utilities_error_state_t *)pthread_getspecific(__utilities_error_state_key);
   char * __utilities_error_string = (char *)pthread_getspecific(__utilities_error_string_key);
 #endif
-  __utilities_reset_error_string(&__utilities_error_string, __utilities_error_state->allocator);
+  if (__utilities_error_state) {
+    __utilities_reset_error_string(&__utilities_error_string, __utilities_error_state->allocator);
+  }
   __utilities_reset_error(&__utilities_error_state);
 }

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -12,227 +12,246 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Note: migrated from rmw/error_handling.c in 2017-04
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <rmw/allocators.h>
-#include <rmw/error_handling.h>
-#include <rmw/impl/config.h>
-#include <rmw/macros.h>
+#include <c_utilities/error_handling.h>
+#include <c_utilities/macros.h>
+
+#ifndef UTILITIES_REPORT_ERROR_HANDLING_ERRORS
+#define UTILITIES_REPORT_ERROR_HANDLING_ERRORS 1
+#endif
 
 #define SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
 
-#ifdef RMW_THREAD_LOCAL_PTHREAD
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
 #include <pthread.h>
-pthread_key_t __rmw_error_state_key;
-pthread_key_t __rmw_error_string_key;
+pthread_key_t __utilities_error_state_key;
+pthread_key_t __utilities_error_string_key;
 #else
-RMW_THREAD_LOCAL rmw_error_state_t * __rmw_error_state = NULL;
-RMW_THREAD_LOCAL char * __rmw_error_string = NULL;
+UTILITIES_THREAD_LOCAL utilities_error_state_t * __utilities_error_state = NULL;
+UTILITIES_THREAD_LOCAL char * __utilities_error_string = NULL;
 #endif
 
 static const char __error_format_string[] = "%s, at %s:%zu";
 
 bool
-__rmw_error_is_set(rmw_error_state_t * error_state);
+__utilities_error_is_set(utilities_error_state_t * error_state);
 
 void
-__rmw_reset_error_string(char ** error_string_ptr);
+__utilities_reset_error_string(char ** error_string_ptr, utilities_allocator_t allocator);
 
 void
-__rmw_reset_error(rmw_error_state_t ** error_state_ptr_ptr);
+__utilities_reset_error(utilities_error_state_t ** error_state_ptr_ptr);
 
 void
-rmw_set_error_state(const char * error_string, const char * file, size_t line_number)
+utilities_set_error_state(
+  const char * error_string,
+  const char * file,
+  size_t line_number,
+  utilities_allocator_t allocator)
 {
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state =
-    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
-  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  utilities_error_state_t * __utilities_error_state =
+    (utilities_error_state_t *)pthread_getspecific(__utilities_error_state_key);
+  char * __utilities_error_string = (char *)pthread_getspecific(__utilities_error_string_key);
 #endif
-  rmw_error_state_t * old_error_state = __rmw_error_state;
-#if RMW_REPORT_ERROR_HANDLING_ERRORS
-  const char * old_error_string = rmw_get_error_string_safe();
+  utilities_error_state_t * old_error_state = __utilities_error_state;
+#if UTILITIES_REPORT_ERROR_HANDLING_ERRORS
+  const char * old_error_string = utilities_get_error_string_safe();
 #endif
-  __rmw_error_state = (rmw_error_state_t *)rmw_allocate(sizeof(rmw_error_state_t));
-  if (!__rmw_error_state) {
-#if RMW_REPORT_ERROR_HANDLING_ERRORS
-    // rmw_allocate failed, but fwrite might work?
+  __utilities_error_state = (utilities_error_state_t *)allocator.allocate(
+    sizeof(utilities_error_state_t), allocator.state);
+  if (!__utilities_error_state) {
+#if UTILITIES_REPORT_ERROR_HANDLING_ERRORS
+    // utilities_allocate failed, but fwrite might work?
     SAFE_FWRITE_TO_STDERR(
-      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "[rmw|error_handling.c:" UTILITIES_STRINGIFY(__LINE__)
       "] failed to allocate memory for the error state struct\n");
 #endif
     return;
   }
+  __utilities_error_state->allocator = allocator;
 
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  pthread_setspecific(__rmw_error_state_key, __rmw_error_state);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  pthread_setspecific(__utilities_error_state_key, __utilities_error_state);
 #endif
   size_t error_string_length = strlen(error_string);
   // the memory must be one byte bigger to store the NULL character
-  __rmw_error_state->message = (char *)malloc(error_string_length + 1);
-  if (!__rmw_error_state->message) {
-#if RMW_REPORT_ERROR_HANDLING_ERRORS
+  __utilities_error_state->message =
+    (char *)allocator.allocate(error_string_length + 1, allocator.state);
+  if (!__utilities_error_state->message) {
+#if UTILITIES_REPORT_ERROR_HANDLING_ERRORS
     // malloc failed, but fwrite might work?
     SAFE_FWRITE_TO_STDERR(
-      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "[rmw|error_handling.c:" UTILITIES_STRINGIFY(__LINE__)
       "] failed to allocate memory for the error message in the error state struct\n");
 #endif
-    rmw_reset_error();  // This will free any allocations done so far.
+    utilities_reset_error();  // This will free any allocations done so far.
     return;
   }
   // Cast the const away to set ->message initially.
 #ifndef _WIN32
-  snprintf((char *)__rmw_error_state->message, error_string_length + 1, "%s", error_string);
+  snprintf((char *)__utilities_error_state->message, error_string_length + 1, "%s", error_string);
 #else
   auto retcode = strcpy_s(
-    (char *)__rmw_error_state->message, error_string_length + 1, error_string);
+    (char *)__utilities_error_state->message, error_string_length + 1, error_string);
   if (retcode) {
-#if RMW_REPORT_ERROR_HANDLING_ERRORS
+#if UTILITIES_REPORT_ERROR_HANDLING_ERRORS
     SAFE_FWRITE_TO_STDERR(
-      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "[rmw|error_handling.c:" UTILITIES_STRINGIFY(__LINE__)
       "] failed to copy error message in the error state struct\n");
 #endif
   }
 #endif
-  __rmw_error_state->file = file;
-  __rmw_error_state->line_number = line_number;
-  if (__rmw_error_is_set(old_error_state)) {
-#if RMW_REPORT_ERROR_HANDLING_ERRORS
+  __utilities_error_state->file = file;
+  __utilities_error_state->line_number = line_number;
+  if (__utilities_error_is_set(old_error_state)) {
+#if UTILITIES_REPORT_ERROR_HANDLING_ERRORS
     // Only warn of overwritting if the new error string is different from the old ones.
     if (error_string != old_error_string && error_string != old_error_state->message) {
       fprintf(
         stderr,
-        "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__) "] error string being overwritten: %s\n",
+        "[rmw|error_handling.c:" UTILITIES_STRINGIFY(__LINE__) "] utilities_set_error_state():"
+        "error string being overwritten: %s\n",
         old_error_string);
     }
 #endif
-    __rmw_reset_error(&old_error_state);
+    __utilities_reset_error(&old_error_state);
   }
-  __rmw_reset_error_string(&__rmw_error_string);
+  __utilities_reset_error_string(&__utilities_error_string, __utilities_error_state->allocator);
 }
 
-const rmw_error_state_t *
-rmw_get_error_state()
+const utilities_error_state_t *
+utilities_get_error_state()
 {
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  return (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  return (utilities_error_state_t *)pthread_getspecific(__utilities_error_state_key);
 #else
-  return __rmw_error_state;
+  return __utilities_error_state;
 #endif
 }
 
 static void
 format_error_string()
 {
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state =
-    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
-  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  utilities_error_state_t * __utilities_error_state =
+    (utilities_error_state_t *)pthread_getspecific(__utilities_error_state_key);
+  char * __utilities_error_string = (char *)pthread_getspecific(__utilities_error_string_key);
 #endif
-  if (!__rmw_error_is_set(__rmw_error_state)) {
+  if (!__utilities_error_is_set(__utilities_error_state)) {
     return;
   }
   size_t bytes_it_would_have_written = snprintf(
     NULL, 0,
     __error_format_string,
-    __rmw_error_state->message, __rmw_error_state->file, __rmw_error_state->line_number);
-  __rmw_error_string = (char *)rmw_allocate(bytes_it_would_have_written + 1);
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  pthread_setspecific(__rmw_error_string_key, __rmw_error_string);
+    __utilities_error_state->message,
+    __utilities_error_state->file,
+    __utilities_error_state->line_number);
+  utilities_allocator_t allocator = __utilities_error_state->allocator;
+  __utilities_error_string =
+    (char *)allocator.allocate(bytes_it_would_have_written + 1, allocator.state);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  pthread_setspecific(__utilities_error_string_key, __utilities_error_string);
 #endif
-  if (!__rmw_error_string) {
-#if RMW_REPORT_ERROR_HANDLING_ERRORS
-    // rmw_allocate failed, but fwrite might work?
+  if (!__utilities_error_string) {
+#if UTILITIES_REPORT_ERROR_HANDLING_ERRORS
+    // utilities_allocate failed, but fwrite might work?
     SAFE_FWRITE_TO_STDERR(
-      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "[rmw|error_handling.c:" UTILITIES_STRINGIFY(__LINE__)
       "] failed to allocate memory for the error string\n");
 #endif
     return;
   }
   snprintf(
-    __rmw_error_string, bytes_it_would_have_written + 1,
+    __utilities_error_string, bytes_it_would_have_written + 1,
     __error_format_string,
-    __rmw_error_state->message, __rmw_error_state->file, __rmw_error_state->line_number);
+    __utilities_error_state->message,
+    __utilities_error_state->file,
+    __utilities_error_state->line_number);
   // The Windows version of snprintf does not null terminate automatically in all cases.
-  __rmw_error_string[bytes_it_would_have_written] = '\0';
+  __utilities_error_string[bytes_it_would_have_written] = '\0';
 }
 
 const char *
-rmw_get_error_string()
+utilities_get_error_string()
 {
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  char * __utilities_error_string = (char *)pthread_getspecific(__utilities_error_string_key);
 #endif
-  if (!__rmw_error_string) {
+  if (!__utilities_error_string) {
     format_error_string();
   }
-  return __rmw_error_string;
+  return __utilities_error_string;
 }
 
 bool
-__rmw_error_is_set(rmw_error_state_t * error_state)
+__utilities_error_is_set(utilities_error_state_t * error_state)
 {
   return error_state != NULL;
 }
 
 bool
-rmw_error_is_set()
+utilities_error_is_set()
 {
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state =
-    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  utilities_error_state_t * __utilities_error_state =
+    (utilities_error_state_t *)pthread_getspecific(__utilities_error_state_key);
 #endif
-  return __rmw_error_is_set(__rmw_error_state);
+  return __utilities_error_is_set(__utilities_error_state);
 }
 
 const char *
-rmw_get_error_string_safe()
+utilities_get_error_string_safe()
 {
-  if (!rmw_error_is_set()) {
+  if (!utilities_error_is_set()) {
     return "error not set";
   }
-  return rmw_get_error_string();
+  return utilities_get_error_string();
 }
 
 void
-__rmw_reset_error_string(char ** error_string_ptr)
+__utilities_reset_error_string(char ** error_string_ptr, utilities_allocator_t allocator)
 {
   char * error_string = *error_string_ptr;
   if (error_string) {
     if (error_string) {
-      rmw_free(error_string);
+      allocator.deallocate(error_string, allocator.state);
     }
   }
   *error_string_ptr = NULL;
 }
 
 void
-__rmw_reset_error(rmw_error_state_t ** error_state_ptr_ptr)
+__utilities_reset_error(utilities_error_state_t ** error_state_ptr_ptr)
 {
-  rmw_error_state_t * error_state_ptr = *error_state_ptr_ptr;
   if (error_state_ptr_ptr) {
+    utilities_error_state_t * error_state_ptr = *error_state_ptr_ptr;
     if (error_state_ptr) {
+      utilities_allocator_t allocator = error_state_ptr->allocator;
       if (error_state_ptr->message) {
         // Cast const away to delete previously allocated memory.
-        rmw_free((char *)error_state_ptr->message);
+        allocator.deallocate((char *)error_state_ptr->message, allocator.state);
       }
-      rmw_free(error_state_ptr);
+      allocator.deallocate(error_state_ptr, allocator.state);
     }
+    *error_state_ptr_ptr = NULL;
   }
-  *error_state_ptr_ptr = NULL;
 }
 
 void
-rmw_reset_error()
+utilities_reset_error()
 {
-#ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state =
-    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
-  char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
+#ifdef UTILITIES_THREAD_LOCAL_PTHREAD
+  utilities_error_state_t * __utilities_error_state =
+    (utilities_error_state_t *)pthread_getspecific(__utilities_error_state_key);
+  char * __utilities_error_string = (char *)pthread_getspecific(__utilities_error_string_key);
 #endif
-  __rmw_reset_error_string(&__rmw_error_string);
-  __rmw_reset_error(&__rmw_error_state);
+  __utilities_reset_error_string(&__utilities_error_string, __utilities_error_state->allocator);
+  __utilities_reset_error(&__utilities_error_state);
 }

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -32,7 +32,10 @@ ament_add_gmock(test_memory_tools test_memory_tools.cpp
 )
 if(TARGET test_memory_tools)
   target_link_libraries(test_memory_tools ${extra_test_libraries})
-  set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
+  if (c_utilities_extra_warning_flags)
+    set_target_properties(test_memory_tools
+      PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
+  endif()
 endif()
 
 set(extra_test_libraries ${extra_test_libraries} PARENT_SCOPE)

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -32,7 +32,7 @@ ament_add_gmock(test_memory_tools test_memory_tools.cpp
 )
 if(TARGET test_memory_tools)
   target_link_libraries(test_memory_tools ${extra_test_libraries})
-  if (c_utilities_extra_warning_flags)
+  if(c_utilities_extra_warning_flags)
     set_target_properties(test_memory_tools
       PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
   endif()

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -1,12 +1,10 @@
-ament_find_gtest()  # For GTEST_LIBRARIES
-
-# Create the memory_tools library which is used by the tests. (rmw implementation agnostic)
+# Create the memory_tools library which is used by the tests.
 add_library(${PROJECT_NAME}_memory_tools SHARED memory_tools.cpp)
 if(APPLE)
   # Create an OS X specific version of the memory tools that does interposing.
   # See: http://toves.freeshell.org/interpose/
   add_library(${PROJECT_NAME}_memory_tools_interpose SHARED memory_tools_osx_interpose.cpp)
-  target_link_libraries(${PROJECT_NAME}_memory_tools_interpose ${GTEST_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_memory_tools_interpose ${GMOCK_LIBRARIES})
   list(APPEND extra_test_libraries ${PROJECT_NAME}_memory_tools_interpose)
   list(APPEND extra_test_env
     DYLD_INSERT_LIBRARIES=$<TARGET_FILE:${PROJECT_NAME}_memory_tools_interpose>)
@@ -28,7 +26,7 @@ if(WIN32)  # (memory tools doesn't do anything on Windows)
   set(SKIP_TEST "SKIP_TEST")
 endif()
 
-ament_add_gtest(test_memory_tools test_memory_tools.cpp
+ament_add_gmock(test_memory_tools test_memory_tools.cpp
   ENV ${extra_test_env}
   ${SKIP_TEST}
 )

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -8,8 +8,7 @@ if(APPLE)
   list(APPEND extra_test_libraries ${PROJECT_NAME}_memory_tools_interpose)
   list(APPEND extra_test_env
     DYLD_INSERT_LIBRARIES=$<TARGET_FILE:${PROJECT_NAME}_memory_tools_interpose>)
-endif()
-if(UNIX AND NOT APPLE)
+elseif(UNIX)
   # On Linux like systems, add dl and use the normal library and DL_PRELOAD.
   list(APPEND extra_test_libraries dl)
   list(APPEND extra_test_env DL_PRELOAD=$<TARGET_FILE:${PROJECT_NAME}_memory_tools>)

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -1,0 +1,41 @@
+ament_find_gtest()  # For GTEST_LIBRARIES
+
+# Create the memory_tools library which is used by the tests. (rmw implementation agnostic)
+add_library(${PROJECT_NAME}_memory_tools SHARED memory_tools.cpp)
+if(APPLE)
+  # Create an OS X specific version of the memory tools that does interposing.
+  # See: http://toves.freeshell.org/interpose/
+  add_library(${PROJECT_NAME}_memory_tools_interpose SHARED memory_tools_osx_interpose.cpp)
+  target_link_libraries(${PROJECT_NAME}_memory_tools_interpose ${GTEST_LIBRARIES})
+  list(APPEND extra_test_libraries ${PROJECT_NAME}_memory_tools_interpose)
+  list(APPEND extra_test_env
+    DYLD_INSERT_LIBRARIES=$<TARGET_FILE:${PROJECT_NAME}_memory_tools_interpose>)
+endif()
+if(UNIX AND NOT APPLE)
+  # On Linux like systems, add dl and use the normal library and DL_PRELOAD.
+  list(APPEND extra_test_libraries dl)
+  list(APPEND extra_test_env DL_PRELOAD=$<TARGET_FILE:${PROJECT_NAME}_memory_tools>)
+endif()
+list(APPEND extra_lib_dirs $<TARGET_FILE_DIR:${PROJECT_NAME}_memory_tools>)
+target_link_libraries(${PROJECT_NAME}_memory_tools ${extra_test_libraries})
+target_compile_definitions(${PROJECT_NAME}_memory_tools
+  PRIVATE "RCL_MEMORY_TOOLS_BUILDING_DLL")
+list(APPEND extra_test_libraries ${PROJECT_NAME}_memory_tools)
+
+# Create tests for the memory tools library.
+set(SKIP_TEST "")
+if(WIN32)  # (memory tools doesn't do anything on Windows)
+  set(SKIP_TEST "SKIP_TEST")
+endif()
+
+ament_add_gtest(test_memory_tools test_memory_tools.cpp
+  ENV ${extra_test_env}
+  ${SKIP_TEST}
+)
+if(TARGET test_memory_tools)
+  target_link_libraries(test_memory_tools ${extra_test_libraries})
+endif()
+
+set(extra_test_libraries ${extra_test_libraries} PARENT_SCOPE)
+set(extra_test_env ${extra_test_env} PARENT_SCOPE)
+set(extra_lib_dirs ${extra_lib_dirs} PARENT_SCOPE)

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -32,6 +32,7 @@ ament_add_gmock(test_memory_tools test_memory_tools.cpp
 )
 if(TARGET test_memory_tools)
   target_link_libraries(test_memory_tools ${extra_test_libraries})
+  set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${c_utilities_extra_warning_flags})
 endif()
 
 set(extra_test_libraries ${extra_test_libraries} PARENT_SCOPE)

--- a/test/memory_tools/memory_tools.cpp
+++ b/test/memory_tools/memory_tools.cpp
@@ -1,0 +1,143 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__linux__)
+/******************************************************************************
+ * Begin Linux
+ *****************************************************************************/
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <malloc.h>
+
+#include "./memory_tools_common.cpp"
+
+void *
+malloc(size_t size)
+{
+  void * (* libc_malloc)(size_t) = (void *(*)(size_t))dlsym(RTLD_NEXT, "malloc");
+  if (enabled.load()) {
+    return custom_malloc(size);
+  }
+  return libc_malloc(size);
+}
+
+void *
+realloc(void * pointer, size_t size)
+{
+  void * (* libc_realloc)(void *, size_t) = (void *(*)(void *, size_t))dlsym(RTLD_NEXT, "realloc");
+  if (enabled.load()) {
+    return custom_realloc(pointer, size);
+  }
+  return libc_realloc(pointer, size);
+}
+
+void
+free(void * pointer)
+{
+  void (* libc_free)(void *) = (void (*)(void *))dlsym(RTLD_NEXT, "free");
+  if (enabled.load()) {
+    return custom_free(pointer);
+  }
+  return libc_free(pointer);
+}
+
+void start_memory_checking()
+{
+  if (!enabled.exchange(true)) {
+    printf("starting memory checking...\n");
+  }
+}
+
+void stop_memory_checking()
+{
+  if (enabled.exchange(false)) {
+    printf("stopping memory checking...\n");
+  }
+}
+
+/******************************************************************************
+ * End Linux
+ *****************************************************************************/
+#elif defined(__APPLE__)
+/******************************************************************************
+ * Begin Apple
+ *****************************************************************************/
+
+// The apple implementation is in a separate shared library, loaded with DYLD_INSERT_LIBRARIES.
+// Therefore we do not include the common cpp file here.
+
+void osx_start_memory_checking();
+void osx_stop_memory_checking();
+
+void start_memory_checking()
+{
+  return osx_start_memory_checking();
+}
+
+void stop_memory_checking()
+{
+  return osx_stop_memory_checking();
+}
+
+/******************************************************************************
+ * End Apple
+ *****************************************************************************/
+// #elif defined(WIN32)
+/******************************************************************************
+ * Begin Windows
+ *****************************************************************************/
+
+// TODO(wjwwood): install custom malloc (and others) for Windows.
+
+/******************************************************************************
+ * End Windows
+ *****************************************************************************/
+#else
+// Default case: do nothing.
+
+#include "./memory_tools.hpp"
+
+#include <stdio.h>
+
+void start_memory_checking()
+{
+  printf("starting memory checking... not available\n");
+}
+void stop_memory_checking()
+{
+  printf("stopping memory checking... not available\n");
+}
+
+void assert_no_malloc_begin() {}
+
+void assert_no_malloc_end() {}
+
+void set_on_unexpected_malloc_callback(UnexpectedCallbackType callback) {}
+
+void assert_no_realloc_begin() {}
+
+void assert_no_realloc_end() {}
+
+void set_on_unexpected_realloc_callback(UnexpectedCallbackType callback) {}
+
+void assert_no_free_begin() {}
+
+void assert_no_free_end() {}
+
+void set_on_unexpected_free_callback(UnexpectedCallbackType callback) {}
+
+void memory_checking_thread_init() {}
+
+#endif  // if defined(__linux__) elif defined(__APPLE__) elif defined(WIN32) else ...

--- a/test/memory_tools/memory_tools.hpp
+++ b/test/memory_tools/memory_tools.hpp
@@ -1,0 +1,132 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code to do replacing of malloc/free/etc... inspired by:
+//   https://dxr.mozilla.org/mozilla-central/rev/
+//    cc9c6cd756cb744596ba039dcc5ad3065a7cc3ea/memory/build/replace_malloc.c
+
+#ifndef MEMORY_TOOLS__MEMORY_TOOLS_HPP_
+#define MEMORY_TOOLS__MEMORY_TOOLS_HPP_
+
+#include <stddef.h>
+
+#include <functional>
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCL_MEMORY_TOOLS_EXPORT __attribute__ ((dllexport))
+    #define RCL_MEMORY_TOOLS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCL_MEMORY_TOOLS_EXPORT __declspec(dllexport)
+    #define RCL_MEMORY_TOOLS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCL_MEMORY_TOOLS_BUILDING_DLL
+    #define RCL_MEMORY_TOOLS_PUBLIC RCL_MEMORY_TOOLS_EXPORT
+  #else
+    #define RCL_MEMORY_TOOLS_PUBLIC RCL_MEMORY_TOOLS_IMPORT
+  #endif
+  #define RCL_MEMORY_TOOLS_PUBLIC_TYPE RCL_MEMORY_TOOLS_PUBLIC
+  #define RCL_MEMORY_TOOLS_LOCAL
+#else
+  #define RCL_MEMORY_TOOLS_EXPORT __attribute__ ((visibility("default")))
+  #define RCL_MEMORY_TOOLS_IMPORT
+  #if __GNUC__ >= 4
+    #define RCL_MEMORY_TOOLS_PUBLIC __attribute__ ((visibility("default")))
+    #define RCL_MEMORY_TOOLS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCL_MEMORY_TOOLS_PUBLIC
+    #define RCL_MEMORY_TOOLS_LOCAL
+  #endif
+  #define RCL_MEMORY_TOOLS_PUBLIC_TYPE
+#endif
+
+typedef std::function<void ()> UnexpectedCallbackType;
+
+RCL_MEMORY_TOOLS_PUBLIC
+void
+start_memory_checking();
+
+#define ASSERT_NO_MALLOC(statements) \
+  assert_no_malloc_begin(); statements; assert_no_malloc_end();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+assert_no_malloc_begin();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+assert_no_malloc_end();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+set_on_unexpected_malloc_callback(UnexpectedCallbackType callback);
+
+#define ASSERT_NO_REALLOC(statements) \
+  assert_no_realloc_begin(); statements; assert_no_realloc_end();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+assert_no_realloc_begin();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+assert_no_realloc_end();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+set_on_unexpected_realloc_callback(UnexpectedCallbackType callback);
+
+#define ASSERT_NO_FREE(statements) \
+  assert_no_free_begin(); statements; assert_no_free_end();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+assert_no_free_begin();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+assert_no_free_end();
+RCL_MEMORY_TOOLS_PUBLIC
+void
+set_on_unexpected_free_callback(UnexpectedCallbackType callback);
+
+RCL_MEMORY_TOOLS_PUBLIC
+void
+stop_memory_checking();
+
+RCL_MEMORY_TOOLS_PUBLIC
+void
+memory_checking_thread_init();
+
+// What follows is a set of failing allocator functions, used for testing.
+void *
+failing_malloc(size_t size, void * state)
+{
+  (void)size;
+  (void)state;
+  return nullptr;
+}
+
+void *
+failing_realloc(void * pointer, size_t size, void * state)
+{
+  (void)pointer;
+  (void)size;
+  (void)state;
+  return nullptr;
+}
+
+void
+failing_free(void * pointer, void * state)
+{
+  (void)pointer;
+  (void)state;
+}
+
+#endif  // MEMORY_TOOLS__MEMORY_TOOLS_HPP_

--- a/test/memory_tools/memory_tools_common.cpp
+++ b/test/memory_tools/memory_tools_common.cpp
@@ -1,0 +1,166 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <inttypes.h>
+
+#include <atomic>
+#include <cstdlib>
+
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#define MALLOC_PRINTF malloc_printf
+#else  // defined(__APPLE__)
+#define MALLOC_PRINTF printf
+#endif  // defined(__APPLE__)
+
+#include "./memory_tools.hpp"
+#include "./scope_exit.hpp"
+
+static std::atomic<bool> enabled(false);
+
+static __thread bool malloc_expected = true;
+static __thread UnexpectedCallbackType * unexpected_malloc_callback = nullptr;
+void set_on_unexpected_malloc_callback(UnexpectedCallbackType callback)
+{
+  if (unexpected_malloc_callback) {
+    unexpected_malloc_callback->~UnexpectedCallbackType();
+    free(unexpected_malloc_callback);
+    unexpected_malloc_callback = nullptr;
+  }
+  if (!callback) {
+    return;
+  }
+  if (!unexpected_malloc_callback) {
+    unexpected_malloc_callback =
+      reinterpret_cast<UnexpectedCallbackType *>(malloc(sizeof(UnexpectedCallbackType)));
+    if (!unexpected_malloc_callback) {
+      throw std::bad_alloc();
+    }
+    new (unexpected_malloc_callback) UnexpectedCallbackType();
+  }
+  *unexpected_malloc_callback = callback;
+}
+
+void *
+custom_malloc(size_t size)
+{
+  if (!enabled.load()) {return malloc(size);}
+  auto foo = SCOPE_EXIT(enabled.store(true););
+  enabled.store(false);
+  if (!malloc_expected) {
+    if (unexpected_malloc_callback) {
+      (*unexpected_malloc_callback)();
+    }
+  }
+  void * memory = malloc(size);
+  uint64_t fw_size = size;
+  if (!malloc_expected) {
+    MALLOC_PRINTF(
+      " malloc (%s) %p %" PRIu64 "\n",
+      malloc_expected ? "    expected" : "not expected", memory, fw_size);
+  }
+  return memory;
+}
+
+static __thread bool realloc_expected = true;
+static __thread UnexpectedCallbackType * unexpected_realloc_callback = nullptr;
+void set_on_unexpected_realloc_callback(UnexpectedCallbackType callback)
+{
+  if (unexpected_realloc_callback) {
+    unexpected_realloc_callback->~UnexpectedCallbackType();
+    free(unexpected_realloc_callback);
+    unexpected_realloc_callback = nullptr;
+  }
+  if (!callback) {
+    return;
+  }
+  if (!unexpected_realloc_callback) {
+    unexpected_realloc_callback =
+      reinterpret_cast<UnexpectedCallbackType *>(malloc(sizeof(UnexpectedCallbackType)));
+    if (!unexpected_realloc_callback) {
+      throw std::bad_alloc();
+    }
+    new (unexpected_realloc_callback) UnexpectedCallbackType();
+  }
+  *unexpected_realloc_callback = callback;
+}
+
+void *
+custom_realloc(void * memory_in, size_t size)
+{
+  if (!enabled.load()) {return realloc(memory_in, size);}
+  auto foo = SCOPE_EXIT(enabled.store(true););
+  enabled.store(false);
+  if (!realloc_expected) {
+    if (unexpected_realloc_callback) {
+      (*unexpected_realloc_callback)();
+    }
+  }
+  void * memory = realloc(memory_in, size);
+  uint64_t fw_size = size;
+  if (!realloc_expected) {
+    MALLOC_PRINTF(
+      "realloc (%s) %p %p %" PRIu64 "\n",
+      realloc_expected ? "    expected" : "not expected", memory_in, memory, fw_size);
+  }
+  return memory;
+}
+
+static __thread bool free_expected = true;
+static __thread UnexpectedCallbackType * unexpected_free_callback = nullptr;
+void set_on_unexpected_free_callback(UnexpectedCallbackType callback)
+{
+  if (unexpected_free_callback) {
+    unexpected_free_callback->~UnexpectedCallbackType();
+    free(unexpected_free_callback);
+    unexpected_free_callback = nullptr;
+  }
+  if (!callback) {
+    return;
+  }
+  if (!unexpected_free_callback) {
+    unexpected_free_callback =
+      reinterpret_cast<UnexpectedCallbackType *>(malloc(sizeof(UnexpectedCallbackType)));
+    if (!unexpected_free_callback) {
+      throw std::bad_alloc();
+    }
+    new (unexpected_free_callback) UnexpectedCallbackType();
+  }
+  *unexpected_free_callback = callback;
+}
+
+void
+custom_free(void * memory)
+{
+  if (!enabled.load()) {return free(memory);}
+  auto foo = SCOPE_EXIT(enabled.store(true););
+  enabled.store(false);
+  if (!free_expected) {
+    if (unexpected_free_callback) {
+      (*unexpected_free_callback)();
+    }
+  }
+  if (!free_expected) {
+    MALLOC_PRINTF(
+      "   free (%s) %p\n", free_expected ? "    expected" : "not expected", memory);
+  }
+  free(memory);
+}
+
+void assert_no_malloc_begin() {malloc_expected = false;}
+void assert_no_malloc_end() {malloc_expected = true;}
+void assert_no_realloc_begin() {realloc_expected = false;}
+void assert_no_realloc_end() {realloc_expected = true;}
+void assert_no_free_begin() {free_expected = false;}
+void assert_no_free_end() {free_expected = true;}

--- a/test/memory_tools/memory_tools_osx_interpose.cpp
+++ b/test/memory_tools/memory_tools_osx_interpose.cpp
@@ -1,0 +1,57 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pulled from:
+//  https://github.com/emeryberger/Heap-Layers/blob/
+//    076e9e7ef53b66380b159e40473b930f25cc353b/wrappers/macinterpose.h
+
+// The interposition data structure (just pairs of function pointers),
+// used an interposition table like the following:
+//
+
+typedef struct interpose_s
+{
+  void * new_func;
+  void * orig_func;
+} interpose_t;
+
+#define OSX_INTERPOSE(newf, oldf) \
+  __attribute__((used)) static const interpose_t \
+  macinterpose ## newf ## oldf __attribute__ ((section("__DATA, __interpose"))) = { \
+    reinterpret_cast<void *>(newf), \
+    reinterpret_cast<void *>(oldf), \
+  }
+
+// End Interpose.
+
+#include "./memory_tools_common.cpp"
+
+void osx_start_memory_checking()
+{
+  // No loading required, it is handled by DYLD_INSERT_LIBRARIES and dynamic library interposing.
+  if (!enabled.exchange(true)) {
+    MALLOC_PRINTF("starting memory checking...\n");
+  }
+}
+
+void osx_stop_memory_checking()
+{
+  if (enabled.exchange(false)) {
+    MALLOC_PRINTF("stopping memory checking...\n");
+  }
+}
+
+OSX_INTERPOSE(custom_malloc, malloc);
+OSX_INTERPOSE(custom_realloc, realloc);
+OSX_INTERPOSE(custom_free, free);

--- a/test/memory_tools/scope_exit.hpp
+++ b/test/memory_tools/scope_exit.hpp
@@ -1,0 +1,40 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEMORY_TOOLS__SCOPE_EXIT_HPP_
+#define MEMORY_TOOLS__SCOPE_EXIT_HPP_
+
+#include <functional>
+
+template<typename Callable>
+struct ScopeExit
+{
+  explicit ScopeExit(Callable callable)
+  : callable_(callable) {}
+  ~ScopeExit() {callable_(); }
+
+private:
+  Callable callable_;
+};
+
+template<typename Callable>
+ScopeExit<Callable>
+make_scope_exit(Callable callable)
+{
+  return ScopeExit<Callable>(callable);
+}
+
+#define SCOPE_EXIT(code) make_scope_exit([&]() {code; })
+
+#endif  // MEMORY_TOOLS__SCOPE_EXIT_HPP_

--- a/test/memory_tools/test_memory_tools.cpp
+++ b/test/memory_tools/test_memory_tools.cpp
@@ -1,0 +1,133 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "./memory_tools.hpp"
+
+/* Tests the allocatation checking tools.
+ */
+TEST(TestMemoryTools, test_allocation_checking_tools) {
+  size_t unexpected_mallocs = 0;
+  auto on_unexpected_malloc = ([&unexpected_mallocs]() {
+    unexpected_mallocs++;
+  });
+  set_on_unexpected_malloc_callback(on_unexpected_malloc);
+  size_t unexpected_reallocs = 0;
+  auto on_unexpected_realloc = ([&unexpected_reallocs]() {
+    unexpected_reallocs++;
+  });
+  set_on_unexpected_realloc_callback(on_unexpected_realloc);
+  size_t unexpected_frees = 0;
+  auto on_unexpected_free = ([&unexpected_frees]() {
+    unexpected_frees++;
+  });
+  set_on_unexpected_free_callback(on_unexpected_free);
+  void * mem = nullptr;
+  void * remem = nullptr;
+  // First try before enabling, should have no effect.
+  mem = malloc(1024);
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  EXPECT_EQ(unexpected_mallocs, 0u);
+  EXPECT_EQ(unexpected_reallocs, 0u);
+  EXPECT_EQ(unexpected_frees, 0u);
+  // Enable checking, but no assert, should have no effect.
+  start_memory_checking();
+  mem = malloc(1024);
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  EXPECT_EQ(unexpected_mallocs, 0u);
+  EXPECT_EQ(unexpected_reallocs, 0u);
+  EXPECT_EQ(unexpected_frees, 0u);
+  // Enable no_* asserts, should increment all once.
+  assert_no_malloc_begin();
+  assert_no_realloc_begin();
+  assert_no_free_begin();
+  mem = malloc(1024);
+  assert_no_malloc_end();
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  assert_no_realloc_end();
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  assert_no_free_end();
+  EXPECT_EQ(unexpected_mallocs, 1u);
+  EXPECT_EQ(unexpected_reallocs, 1u);
+  EXPECT_EQ(unexpected_frees, 1u);
+  // Enable on malloc assert, only malloc should increment.
+  assert_no_malloc_begin();
+  mem = malloc(1024);
+  assert_no_malloc_end();
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  EXPECT_EQ(unexpected_mallocs, 2u);
+  EXPECT_EQ(unexpected_reallocs, 1u);
+  EXPECT_EQ(unexpected_frees, 1u);
+  // Enable on realloc assert, only realloc should increment.
+  assert_no_realloc_begin();
+  mem = malloc(1024);
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  assert_no_realloc_end();
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  EXPECT_EQ(unexpected_mallocs, 2u);
+  EXPECT_EQ(unexpected_reallocs, 2u);
+  EXPECT_EQ(unexpected_frees, 1u);
+  // Enable on free assert, only free should increment.
+  assert_no_free_begin();
+  mem = malloc(1024);
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  assert_no_free_end();
+  EXPECT_EQ(unexpected_mallocs, 2u);
+  EXPECT_EQ(unexpected_reallocs, 2u);
+  EXPECT_EQ(unexpected_frees, 2u);
+  // Go again, after disabling asserts, should have no effect.
+  mem = malloc(1024);
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  EXPECT_EQ(unexpected_mallocs, 2u);
+  EXPECT_EQ(unexpected_reallocs, 2u);
+  EXPECT_EQ(unexpected_frees, 2u);
+  // Go once more after disabling everything, should have no effect.
+  stop_memory_checking();
+  mem = malloc(1024);
+  ASSERT_NE(mem, nullptr);
+  remem = realloc(mem, 2048);
+  ASSERT_NE(remem, nullptr);
+  if (!remem) {free(mem);}
+  free(remem);
+  EXPECT_EQ(unexpected_mallocs, 2u);
+  EXPECT_EQ(unexpected_reallocs, 2u);
+  EXPECT_EQ(unexpected_frees, 2u);
+}

--- a/test/memory_tools/test_memory_tools.cpp
+++ b/test/memory_tools/test_memory_tools.cpp
@@ -16,7 +16,7 @@
 
 #include "./memory_tools.hpp"
 
-/* Tests the allocatation checking tools.
+/* Tests the allocation checking tools.
  */
 TEST(TestMemoryTools, test_allocation_checking_tools) {
   size_t unexpected_mallocs = 0;

--- a/test/memory_tools/test_memory_tools.cpp
+++ b/test/memory_tools/test_memory_tools.cpp
@@ -41,7 +41,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   ASSERT_NE(mem, nullptr);
   remem = realloc(mem, 2048);
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   EXPECT_EQ(unexpected_mallocs, 0u);
   EXPECT_EQ(unexpected_reallocs, 0u);
@@ -52,7 +51,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   ASSERT_NE(mem, nullptr);
   remem = realloc(mem, 2048);
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   EXPECT_EQ(unexpected_mallocs, 0u);
   EXPECT_EQ(unexpected_reallocs, 0u);
@@ -67,7 +65,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   remem = realloc(mem, 2048);
   assert_no_realloc_end();
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   assert_no_free_end();
   EXPECT_EQ(unexpected_mallocs, 1u);
@@ -80,7 +77,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   ASSERT_NE(mem, nullptr);
   remem = realloc(mem, 2048);
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   EXPECT_EQ(unexpected_mallocs, 2u);
   EXPECT_EQ(unexpected_reallocs, 1u);
@@ -92,7 +88,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   remem = realloc(mem, 2048);
   assert_no_realloc_end();
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   EXPECT_EQ(unexpected_mallocs, 2u);
   EXPECT_EQ(unexpected_reallocs, 2u);
@@ -103,7 +98,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   ASSERT_NE(mem, nullptr);
   remem = realloc(mem, 2048);
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   assert_no_free_end();
   EXPECT_EQ(unexpected_mallocs, 2u);
@@ -114,7 +108,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   ASSERT_NE(mem, nullptr);
   remem = realloc(mem, 2048);
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   EXPECT_EQ(unexpected_mallocs, 2u);
   EXPECT_EQ(unexpected_reallocs, 2u);
@@ -125,7 +118,6 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   ASSERT_NE(mem, nullptr);
   remem = realloc(mem, 2048);
   ASSERT_NE(remem, nullptr);
-  if (!remem) {free(mem);}
   free(remem);
   EXPECT_EQ(unexpected_mallocs, 2u);
   EXPECT_EQ(unexpected_reallocs, 2u);

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -1,0 +1,90 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcl/allocator.h"
+
+#include "../memory_tools/memory_tools.hpp"
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME (TestAllocatorFixture, RMW_IMPLEMENTATION) : public ::testing::Test
+{
+public:
+  CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION)() {
+    start_memory_checking();
+    stop_memory_checking();
+  }
+  void SetUp()
+  {
+    set_on_unexpected_malloc_callback([]() {EXPECT_FALSE(true) << "UNEXPECTED MALLOC";});
+    set_on_unexpected_realloc_callback([]() {EXPECT_FALSE(true) << "UNEXPECTED REALLOC";});
+    set_on_unexpected_free_callback([]() {EXPECT_FALSE(true) << "UNEXPECTED FREE";});
+    start_memory_checking();
+  }
+
+  void TearDown()
+  {
+    assert_no_malloc_end();
+    assert_no_realloc_end();
+    assert_no_free_end();
+    stop_memory_checking();
+    set_on_unexpected_malloc_callback(nullptr);
+    set_on_unexpected_realloc_callback(nullptr);
+    set_on_unexpected_free_callback(nullptr);
+  }
+};
+
+/* Tests the default allocator.
+ */
+TEST_F(CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION), test_default_allocator_normal) {
+#if defined(WIN32)
+  printf("Allocator tests disabled on Windows.\n");
+  return;
+#endif  // defined(WIN32)
+  ASSERT_NO_MALLOC(
+    rcl_allocator_t allocator = rcl_get_default_allocator();
+  )
+  size_t mallocs = 0;
+  size_t reallocs = 0;
+  size_t frees = 0;
+  set_on_unexpected_malloc_callback([&mallocs]() {
+    mallocs++;
+  });
+  set_on_unexpected_realloc_callback([&reallocs]() {
+    reallocs++;
+  });
+  set_on_unexpected_free_callback([&frees]() {
+    frees++;
+  });
+  assert_no_malloc_begin();
+  assert_no_realloc_begin();
+  assert_no_free_begin();
+  void * allocated_memory = allocator.allocate(1024, allocator.state);
+  EXPECT_EQ(mallocs, 1u);
+  EXPECT_NE(allocated_memory, nullptr);
+  allocated_memory = allocator.reallocate(allocated_memory, 2048, allocator.state);
+  EXPECT_EQ(reallocs, 1u);
+  EXPECT_NE(allocated_memory, nullptr);
+  allocator.deallocate(allocated_memory, allocator.state);
+  EXPECT_EQ(mallocs, 1u);
+  EXPECT_EQ(reallocs, 1u);
+  EXPECT_EQ(frees, 1u);
+}

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -14,9 +14,9 @@
 
 #include <gtest/gtest.h>
 
-#include "rcl/allocator.h"
+#include "c_utilities/allocator.h"
 
-#include "../memory_tools/memory_tools.hpp"
+#include "./memory_tools/memory_tools.hpp"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
@@ -55,12 +55,8 @@ public:
 /* Tests the default allocator.
  */
 TEST_F(CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION), test_default_allocator_normal) {
-#if defined(WIN32)
-  printf("Allocator tests disabled on Windows.\n");
-  return;
-#endif  // defined(WIN32)
   ASSERT_NO_MALLOC(
-    rcl_allocator_t allocator = rcl_get_default_allocator();
+    utilities_allocator_t allocator = utilities_get_default_allocator();
   )
   size_t mallocs = 0;
   size_t reallocs = 0;

--- a/test/test_error_handling.cpp
+++ b/test/test_error_handling.cpp
@@ -1,0 +1,89 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "gmock/gmock.h"
+
+#include "rmw/error_handling.h"
+
+int
+count_substrings(const std::string & str, const std::string & substr)
+{
+  if (substr.length() == 0) {
+    return 0;
+  }
+  int count = 0;
+  for (
+    size_t offset = str.find(substr);
+    offset != std::string::npos;
+    offset = str.find(substr, offset + substr.length()))
+  {
+    ++count;
+  }
+  return count;
+}
+
+TEST(test_error_handling, nominal) {
+  rmw_reset_error();
+  const char * test_message = "test message";
+  RMW_SET_ERROR_MSG(test_message);
+  using ::testing::StartsWith;
+  ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+  rmw_reset_error();
+}
+
+TEST(test_error_handling, reset) {
+  rmw_reset_error();
+  {
+    const char * test_message = "test message";
+    RMW_SET_ERROR_MSG(test_message);
+    using ::testing::StartsWith;
+    ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+  }
+  rmw_reset_error();
+  {
+    const char * test_message = "different message";
+    RMW_SET_ERROR_MSG(test_message);
+    using ::testing::StartsWith;
+    ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+  }
+  rmw_reset_error();
+  ASSERT_EQ(nullptr, rmw_get_error_string());
+  ASSERT_NE(nullptr, rmw_get_error_string_safe());
+  ASSERT_STREQ("error not set", rmw_get_error_string_safe());
+  rmw_reset_error();
+}
+
+TEST(test_error_handling, empty) {
+  rmw_reset_error();
+  ASSERT_EQ(nullptr, rmw_get_error_string());
+  ASSERT_NE(nullptr, rmw_get_error_string_safe());
+  ASSERT_STREQ("error not set", rmw_get_error_string_safe());
+  rmw_reset_error();
+}
+
+TEST(test_error_handling, recursive) {
+  rmw_reset_error();
+  const char * test_message = "test message";
+  RMW_SET_ERROR_MSG(test_message);
+  using ::testing::HasSubstr;
+  ASSERT_THAT(rmw_get_error_string_safe(), HasSubstr(", at"));
+  RMW_SET_ERROR_MSG(rmw_get_error_string_safe());
+  std::string err_msg(rmw_get_error_string_safe());
+  int count = count_substrings(err_msg, ", at");
+  EXPECT_EQ(2, count) <<
+    "Expected ', at' in the error string twice but got it '" << count << "': " << err_msg;
+  rmw_reset_error();
+}

--- a/test/test_error_handling.cpp
+++ b/test/test_error_handling.cpp
@@ -16,7 +16,7 @@
 
 #include "gmock/gmock.h"
 
-#include "rmw/error_handling.h"
+#include "c_utilities/error_handling.h"
 
 int
 count_substrings(const std::string & str, const std::string & substr)
@@ -36,54 +36,54 @@ count_substrings(const std::string & str, const std::string & substr)
 }
 
 TEST(test_error_handling, nominal) {
-  rmw_reset_error();
+  utilities_reset_error();
   const char * test_message = "test message";
-  RMW_SET_ERROR_MSG(test_message);
+  UTILITIES_SET_ERROR_MSG(test_message, utilities_get_default_allocator());
   using ::testing::StartsWith;
-  ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
-  rmw_reset_error();
+  ASSERT_THAT(utilities_get_error_string_safe(), StartsWith(test_message));
+  utilities_reset_error();
 }
 
 TEST(test_error_handling, reset) {
-  rmw_reset_error();
+  utilities_reset_error();
   {
     const char * test_message = "test message";
-    RMW_SET_ERROR_MSG(test_message);
+    UTILITIES_SET_ERROR_MSG(test_message, utilities_get_default_allocator());
     using ::testing::StartsWith;
-    ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+    ASSERT_THAT(utilities_get_error_string_safe(), StartsWith(test_message));
   }
-  rmw_reset_error();
+  utilities_reset_error();
   {
     const char * test_message = "different message";
-    RMW_SET_ERROR_MSG(test_message);
+    UTILITIES_SET_ERROR_MSG(test_message, utilities_get_default_allocator());
     using ::testing::StartsWith;
-    ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+    ASSERT_THAT(utilities_get_error_string_safe(), StartsWith(test_message));
   }
-  rmw_reset_error();
-  ASSERT_EQ(nullptr, rmw_get_error_string());
-  ASSERT_NE(nullptr, rmw_get_error_string_safe());
-  ASSERT_STREQ("error not set", rmw_get_error_string_safe());
-  rmw_reset_error();
+  utilities_reset_error();
+  ASSERT_EQ(nullptr, utilities_get_error_string());
+  ASSERT_NE(nullptr, utilities_get_error_string_safe());
+  ASSERT_STREQ("error not set", utilities_get_error_string_safe());
+  utilities_reset_error();
 }
 
 TEST(test_error_handling, empty) {
-  rmw_reset_error();
-  ASSERT_EQ(nullptr, rmw_get_error_string());
-  ASSERT_NE(nullptr, rmw_get_error_string_safe());
-  ASSERT_STREQ("error not set", rmw_get_error_string_safe());
-  rmw_reset_error();
+  utilities_reset_error();
+  ASSERT_EQ(nullptr, utilities_get_error_string());
+  ASSERT_NE(nullptr, utilities_get_error_string_safe());
+  ASSERT_STREQ("error not set", utilities_get_error_string_safe());
+  utilities_reset_error();
 }
 
 TEST(test_error_handling, recursive) {
-  rmw_reset_error();
+  utilities_reset_error();
   const char * test_message = "test message";
-  RMW_SET_ERROR_MSG(test_message);
+  UTILITIES_SET_ERROR_MSG(test_message, utilities_get_default_allocator());
   using ::testing::HasSubstr;
-  ASSERT_THAT(rmw_get_error_string_safe(), HasSubstr(", at"));
-  RMW_SET_ERROR_MSG(rmw_get_error_string_safe());
-  std::string err_msg(rmw_get_error_string_safe());
+  ASSERT_THAT(utilities_get_error_string_safe(), HasSubstr(", at"));
+  UTILITIES_SET_ERROR_MSG(utilities_get_error_string_safe(), utilities_get_default_allocator());
+  std::string err_msg(utilities_get_error_string_safe());
   int count = count_substrings(err_msg, ", at");
   EXPECT_EQ(2, count) <<
     "Expected ', at' in the error string twice but got it '" << count << "': " << err_msg;
-  rmw_reset_error();
+  utilities_reset_error();
 }


### PR DESCRIPTION
This should help with ros2/rmw#94 and #6.

Pull requests to remove the duplicate functionality in `rmw` and `rcl` will follow, but the pr for gmock (https://github.com/ament/ament_cmake/pull/91) can be merged at anytime.

I tried to take care to have a "move" commit and then a "change" commit.